### PR TITLE
change time.Time types to int64 unix timestamps

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/gochain-io/gochain/v3/common"
 	cid "github.com/ipfs/go-cid"
@@ -26,14 +25,14 @@ type API interface {
 	Status(ctx context.Context, ci cid.Cid) (StatusResponse, error)
 }
 type AddResponse struct {
-	CID        string    `json:"cid"`
-	Expiration time.Time `json:"expiration"`
-	Size       int64     `json:"size"` // File size in bytes.
+	CID        string `json:"cid"`
+	Expiration int64  `json:"expiration"` // Unix TS
+	Size       int64  `json:"size"`       // File size in bytes.
 }
 
 type StatusResponse struct {
-	Expiration time.Time `json:"expiration,omitempty"`
-	Size       int64     `json:"size"` // File size in bytes.
+	Expiration int64 `json:"expiration,omitempty"` // Unix TS
+	Size       int64 `json:"size"`                 // File size in bytes.
 }
 
 func NewClient(url string) API {

--- a/cmd/gofs/main.go
+++ b/cmd/gofs/main.go
@@ -368,7 +368,7 @@ func Add(ctx context.Context, apiURL, path string) error {
 	}
 	fmt.Println("File uploaded and pinned.")
 	fmt.Println("CID:", ar.CID)
-	fmt.Println("Pinned until:", ar.Expiration)
+	fmt.Println("Pinned until:", time.Unix(ar.Expiration, 0))
 	fmt.Println("File size:", units.Base2Bytes(ar.Size))
 	return nil
 }
@@ -448,15 +448,16 @@ func Status(ctx context.Context, apiURL, ci string) error {
 	if err != nil {
 		return err
 	}
-	if st.Expiration == (time.Time{}) {
+	if st.Expiration == 0 {
 		fmt.Println("Never been pinned.")
 		return nil
 	}
 	fmt.Println("File size:", units.Base2Bytes(st.Size))
-	if until := time.Until(st.Expiration); until > 0 {
-		fmt.Printf("Expires in %s at %s.\n", until, st.Expiration)
+	exp := time.Unix(st.Expiration, 0)
+	if until := time.Until(exp).Round(time.Second); until > 0 {
+		fmt.Printf("Expires in %s at %s.\n", until, exp)
 	} else {
-		fmt.Printf("Expired %s ago at %s.\n", -until, st.Expiration)
+		fmt.Printf("Expired %s ago at %s.\n", -until, exp)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR changes the time types of the Add and Status responses from `time.Time` to `int64` Unix timestamps. The motivation for this change will be more clear in the corresponding server change, but essentially `time.Time` was difficult to work with for our use case, and the extra precision was not necessary anyways.