### PR TITLE
add go get command before install in cli README.md

### DIFF
--- a/cmd/gofs/README.md
+++ b/cmd/gofs/README.md
@@ -7,6 +7,7 @@ The `gofs` command line interface provides access to both the contract and the w
 Quickest:
 
 ```shell script
+> go get github.com/gochain/gofs/cmd/gofs
 > go install github.com/gochain/gofs/cmd/gofs
 ```
 


### PR DESCRIPTION
I had to run the `go get` command first before being able to install, should probably be added to the README.md